### PR TITLE
Update use-unified-attributes.md

### DIFF
--- a/2.x/use-unified-attributes.md
+++ b/2.x/use-unified-attributes.md
@@ -185,9 +185,7 @@ class PublishNewArticle
     public function asController(ActionRequest $request)
     {
         $this->fillFromRequest($request);
-        $article = $this->handle($request->user());
-
-        return $this->author->articles()->create($validatedData);
+        return $this->handle($request->user());
     }
 }
 ```


### PR DESCRIPTION
Unified attributes code example seemed wrong, as the article was created twice. Hopefully, this suggested change is sensible?