### PR TITLE
added evaluation statement for shouldNotRun-call

### DIFF
--- a/2.x/mock-and-test.md
+++ b/2.x/mock-and-test.md
@@ -34,6 +34,9 @@ FetchContactsFromGoogle::shouldNotRun();
 
 // Equivalent to:
 FetchContactsFromGoogle::mock()->shouldNotReceive('handle');
+
+// needed at the end to evaluate shouldNotRun
+Mockery::close();
 ```
 
 ## Partial mocking


### PR DESCRIPTION
Added the `Mockery::close()` call in the documentation (mock-and-test), when using `shouldNotReceive`. Otherwise it will not be evaluated.