### PR TITLE
Update code example to remove some letters from alphabet

### DIFF
--- a/2.x/examples/generate-reservation-code.md
+++ b/2.x/examples/generate-reservation-code.md
@@ -9,7 +9,7 @@ class GenerateReservationCode
 {
     use AsAction;
 
-    const UNAMBIGUOUS_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    const UNAMBIGUOUS_ALPHABET = 'BCDFGHJLMNPRSTVWXYZ2456789';
 
     public function handle(int $characters = 7): string
     {


### PR DESCRIPTION
Hi @lorisleiva, feel free to take this or leave it... The example reservation code generator is prone to generating some offensive words, I thought that since people may see this as a very useful example that they might be inclined to copy it!