### PR TITLE
Add example for asserting chained jobs

### DIFF
--- a/2.x/as-job.md
+++ b/2.x/as-job.md
@@ -87,6 +87,20 @@ Bus::chain([
 ])->dispatch();
 ```
 
+To assert a job was chained:
+
+```php
+use Illuminate\Support\Facades\Bus;
+
+Bus::fake();
+
+Bus::assertChained([
+    CreateNewTeamReport::makeJob($team),
+    OptimizeTeamReport::makeJob($team),
+    SendTeamReportEmail::makeJob($team),
+]);
+```
+
 ### `assertPushed`
 Asserts the action was dispatched.
 

--- a/2.x/as-job.md
+++ b/2.x/as-job.md
@@ -87,7 +87,7 @@ Bus::chain([
 ])->dispatch();
 ```
 
-To assert a job was chained:
+Finally, note that you can assert a job was chained by mocking the `Bus` facade like so.
 
 ```php
 use Illuminate\Support\Facades\Bus;


### PR DESCRIPTION
There isn't an assertChained equivelant to assertPushed, so in lieu of a PR adding that I'm suggesting an example showing how to test chained actions.

Inspired after spending a bunch of time trying to figure it out, and then coming across the solution in this issue:

https://github.com/lorisleiva/laravel-actions/issues/236

I don't thinks this is the ideal solution - but I think it could make the docs helpful and make it easier for people to test.

I could probably find time to add an assertChained method over the next few months if that's preferred.